### PR TITLE
[SRV-225] standardize thread pool size

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -1,7 +1,6 @@
 #ifndef THREAD_POOL_H
 #define THREAD_POOL_H
 
-#include <cassert>
 #include <condition_variable>
 #include <functional>
 #include <future>

--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -34,7 +34,7 @@ class ThreadPool {
  private:
   // perform initialization
   template <class F>
-  void setup(std::size_t num_threads, F &&initialize, std::size_t stack_size);
+  void setup(std::size_t num_threads, F&& initialize, std::size_t stack_size);
 
   // need to keep track of threads so we can join them
   std::vector<pthread_t> threads;
@@ -96,7 +96,7 @@ inline void ThreadPool::setup(std::size_t num_threads, F &&initialize,
 // the constructor just launches some amount of workers and calls the
 // initializer in each
 template <class F>
-inline ThreadPool::ThreadPool(std::size_t num_threads, F &&initialize,
+inline ThreadPool::ThreadPool(std::size_t num_threads, F&& initialize,
                               std::size_t stack_size)
     : stop(false) {
   setup(num_threads, std::forward<F>(initialize), stack_size);
@@ -108,7 +108,7 @@ inline ThreadPool::ThreadPool(std::size_t num_threads)
 
 // add new work item to the pool
 template <class F, class... Args>
-auto ThreadPool::enqueue(F &&f, Args &&...args)
+auto ThreadPool::enqueue(F&& f, Args&&... args)
     -> std::future<typename std::result_of<F(Args...)>::type> {
   using return_type = typename std::result_of<F(Args...)>::type;
 

--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -12,26 +12,26 @@
 #include <vector>
 
 class ThreadPool {
-public:
+ public:
   static constexpr std::size_t kDefaultStackSize{8 * 1024 * 1024};
 
-public:
+ public:
   static void* entry_point(void* context);
 
-public:
-  explicit ThreadPool(std::size_t threads);
+ public:
+  explicit ThreadPool(std::size_t num_threads);
 
   template <class F>
-  ThreadPool(std::size_t threads, F &&initialize,
+  ThreadPool(std::size_t num_threads, F &&initialize,
              std::size_t stack_size = kDefaultStackSize);
 
   template <class F, class... Args>
-  auto enqueue(F &&f, Args &&...args)
+  auto enqueue(F&& f, Args&&... args)
       -> std::future<typename std::result_of<F(Args...)>::type>;
   std::size_t thread_count() const;
   ~ThreadPool();
 
-private:
+ private:
   // perform initialization
   template <class F>
   void setup(std::size_t num_threads, F &&initialize, std::size_t stack_size);
@@ -96,15 +96,15 @@ inline void ThreadPool::setup(std::size_t num_threads, F &&initialize,
 // the constructor just launches some amount of workers and calls the
 // initializer in each
 template <class F>
-inline ThreadPool::ThreadPool(std::size_t threads, F &&initialize,
+inline ThreadPool::ThreadPool(std::size_t num_threads, F &&initialize,
                               std::size_t stack_size)
     : stop(false) {
-  setup(threads, std::forward<F>(initialize), stack_size);
+  setup(num_threads, std::forward<F>(initialize), stack_size);
 }
 
 // this constructor just launches the workers.
-inline ThreadPool::ThreadPool(std::size_t threads)
-    : ThreadPool(threads, []() {}) {}
+inline ThreadPool::ThreadPool(std::size_t num_threads)
+    : ThreadPool(num_threads, []() {}) {}
 
 // add new work item to the pool
 template <class F, class... Args>


### PR DESCRIPTION
# Changes

The thread pool uses `std::thread` to spawn off threads. This unfortunately means that there will be different stack size values between different platforms, this is specifically a problem when dealing with stack heavy applications like albatross.
This was recently a problem when a platform had by default a low stack size.

The changes done here are centered around changes in the `ThreadPool` so that it doesn't spawn of threads that are sized in a platform dependent manner, now users are given the option to be explicit about the size. This means that we are now locked into using pthread library (for now, can add more in the future), which shouldn't be a problem for us.